### PR TITLE
Only build/push docker images for commits on main branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,12 @@
+name: CI for spectrum4
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: build and test spectrum4
+        run: ./tup-under-docker.sh
+      - name: ensure no local file changes present
+        run: git status && test $(git status --porcelain | wc -l) == 0

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,5 +1,8 @@
 name: CI for spectrum4
-on: [push, pull_request]
+on:
+  push:
+    branches:    
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +18,3 @@ jobs:
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
       - name: build/push docker images
         run: docker/build.sh
-      - name: build and test spectrum4
-        run: ./tup-under-docker.sh
-      - name: ensure no local file changes present
-        run: git status && test $(git status --porcelain | wc -l) == 0


### PR DESCRIPTION
This should prevent that a forked repo can cause invalid docker images to be pushed to hub.docker.com.