### PR TITLE
Add interrupt handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ programs, machine code routines, and RAM disk storage.
 
 ## Execution context
 
-  * Spectrum +4 runs at EL3
-  * MMU is not enabled
+  * Spectrum +4 runs at EL1
+  * MMU is not yet enabled
   * EL3 data cache is enabled
   * EL3 instruction cache is enabled
-  * Currently interrupts are not enabled (keyboard routines not yet written)
+  * Timer interrupts configured and enabled, but keyboard routines not yet written
 
 ## Code organisation
 

--- a/src/spectrum4/kernel/entry.s
+++ b/src/spectrum4/kernel/entry.s
@@ -1,0 +1,138 @@
+# This file is part of the Spectrum +4 Project.
+# Licencing information can be found in the LICENCE file
+# (C) 2021 Spectrum +4 Authors. All rights reserved.
+
+# Based on https://raw.githubusercontent.com/s-matyukevich/raspberry-pi-os/master/src/lesson03/src/entry.S
+
+
+.macro handle_invalid_entry type
+  kernel_entry
+  mov     x0, #\type
+  mrs     x1, esr_el1
+  mrs     x2, elr_el1
+  bl      show_invalid_entry_message
+  b       sleep
+.endm
+
+.macro ventry label
+  .align 7
+  b       \label
+.endm
+
+.macro kernel_entry
+  sub     sp, sp, #16 * 16
+  stp     x0, x1, [sp, #16 * 0]
+  stp     x2, x3, [sp, #16 * 1]
+  stp     x4, x5, [sp, #16 * 2]
+  stp     x6, x7, [sp, #16 * 3]
+  stp     x8, x9, [sp, #16 * 4]
+  stp     x10, x11, [sp, #16 * 5]
+  stp     x12, x13, [sp, #16 * 6]
+  stp     x14, x15, [sp, #16 * 7]
+  stp     x16, x17, [sp, #16 * 8]
+  stp     x18, x19, [sp, #16 * 9]
+  stp     x20, x21, [sp, #16 * 10]
+  stp     x22, x23, [sp, #16 * 11]
+  stp     x24, x25, [sp, #16 * 12]
+  stp     x26, x27, [sp, #16 * 13]
+  stp     x28, x29, [sp, #16 * 14]
+  str     x30, [sp, #16 * 15]
+.endm
+
+.macro kernel_exit
+  ldp     x0, x1, [sp, #16 * 0]
+  ldp     x2, x3, [sp, #16 * 1]
+  ldp     x4, x5, [sp, #16 * 2]
+  ldp     x6, x7, [sp, #16 * 3]
+  ldp     x8, x9, [sp, #16 * 4]
+  ldp     x10, x11, [sp, #16 * 5]
+  ldp     x12, x13, [sp, #16 * 6]
+  ldp     x14, x15, [sp, #16 * 7]
+  ldp     x16, x17, [sp, #16 * 8]
+  ldp     x18, x19, [sp, #16 * 9]
+  ldp     x20, x21, [sp, #16 * 10]
+  ldp     x22, x23, [sp, #16 * 11]
+  ldp     x24, x25, [sp, #16 * 12]
+  ldp     x26, x27, [sp, #16 * 13]
+  ldp     x28, x29, [sp, #16 * 14]
+  ldr     x30, [sp, #16 * 15]
+  add     sp, sp, #16 * 16
+  eret
+.endm
+
+/*
+ * Exception vectors.
+ */
+.align 11
+vectors:
+  ventry  sync_invalid_el1t                       // Synchronous EL1t
+  ventry  irq_invalid_el1t                        // IRQ EL1t
+  ventry  fiq_invalid_el1t                        // FIQ EL1t
+  ventry  error_invalid_el1t                      // Error EL1t
+
+  ventry  sync_invalid_el1h                       // Synchronous EL1h
+  ventry  el1_irq                                 // IRQ EL1h
+  ventry  fiq_invalid_el1h                        // FIQ EL1h
+  ventry  error_invalid_el1h                      // Error EL1h
+
+  ventry  sync_invalid_el0_64                     // Synchronous 64-bit EL0
+  ventry  irq_invalid_el0_64                      // IRQ 64-bit EL0
+  ventry  fiq_invalid_el0_64                      // FIQ 64-bit EL0
+  ventry  error_invalid_el0_64                    // Error 64-bit EL0
+
+  ventry  sync_invalid_el0_32                     // Synchronous 32-bit EL0
+  ventry  irq_invalid_el0_32                      // IRQ 32-bit EL0
+  ventry  fiq_invalid_el0_32                      // FIQ 32-bit EL0
+  ventry  error_invalid_el0_32                    // Error 32-bit EL0
+
+.align 2
+sync_invalid_el1t:
+  handle_invalid_entry  0
+
+irq_invalid_el1t:
+  handle_invalid_entry  1
+
+fiq_invalid_el1t:
+  handle_invalid_entry  2
+
+error_invalid_el1t:
+  handle_invalid_entry  3
+
+sync_invalid_el1h:
+  handle_invalid_entry  4
+
+el1_irq:
+  kernel_entry
+  ldr     x0, handle_irq
+  blr     x0
+  kernel_exit
+
+fiq_invalid_el1h:
+  handle_invalid_entry  6
+
+error_invalid_el1h:
+  handle_invalid_entry  7
+
+sync_invalid_el0_64:
+  handle_invalid_entry  8
+
+irq_invalid_el0_64:
+  handle_invalid_entry  9
+
+fiq_invalid_el0_64:
+  handle_invalid_entry  10
+
+error_invalid_el0_64:
+  handle_invalid_entry  11
+
+sync_invalid_el0_32:
+  handle_invalid_entry  12
+
+irq_invalid_el0_32:
+  handle_invalid_entry  13
+
+fiq_invalid_el0_32:
+  handle_invalid_entry  14
+
+error_invalid_el0_32:
+  handle_invalid_entry  15

--- a/src/spectrum4/kernel/irq.s
+++ b/src/spectrum4/kernel/irq.s
@@ -1,0 +1,127 @@
+# This file is part of the Spectrum +4 Project.
+# Licencing information can be found in the LICENCE file
+# (C) 2021 Spectrum +4 Authors. All rights reserved.
+
+
+# Note, Raspberry Pi docs suggest that using the legacy interrupt controller on
+# rpi4/rpi400 requires setting `enable_gic=0` in the config.txt file:
+#   * https://www.raspberrypi.com/documentation/computers/legacy_config_txt.html#enable_gic-raspberry-pi-4-only
+#
+# However, this code seems to work with the legacy controller even without this
+# setting in config.txt. Perhaps this is because we set `kernel_old=1`
+# and thus skip the code in:
+#
+#   * https://github.com/raspberrypi/tools/blob/master/armstubs/armstub8.S
+#
+# Alternatively, maybe since the setting `enable_gic` is itself a legacy setting
+# maybe the legacy interrupt controller is active by default, and this setting
+# has no bearing.
+#
+# Or another possibility - this setting was interpreted by the Linux kernel
+# rather than the GPU when bringing up the ARM and the peripheral devices.
+#
+# TODO: take a look at the stub to see if it is responsible for disabling the
+# legacy interrupt controller. If it isn't, try to find out why we didn't
+# need to explicitly enable it, or check if we are inadvertently using the
+# GIC or something else without realising it.
+#
+# There seems to be a walkthrough of the stub code here:
+#
+#   * https://leiradel.github.io/2019/01/20/Raspberry-Pi-Stubs.html#armstub8s
+
+
+.align 2
+irq_vector_init:
+  adr     x0, vectors                             // load VBAR_EL1 with virtual
+  msr     vbar_el1, x0                            // vector table address
+  ret
+
+
+enable_irq:
+  msr     daifclr, #2
+  ret
+
+
+disable_irq:
+  msr     daifset, #2
+  ret
+
+
+show_invalid_entry_message:
+  logregs
+  ret
+
+
+enable_ic_bcm283x:
+  mov     w0, #0x00000002
+  movl    w1, 0x3f00b200
+  str     w0, [x1, #0x10]                         // [0x3f00b210] = 0x00000002
+  ret
+
+
+enable_ic_bcm2711:
+  mov     w0, #0x00000002
+  movl    w1, 0xfe00b200
+  str     w0, [x1, #0x10]                         // [0xfe00b210] = 0x00000002
+  ret
+
+
+handle_irq_bcm283x:
+  stp     x29, x30, [sp, #-16]!                   // Push frame pointer, procedure link register on stack.
+  mov     x29, sp                                 // Update frame pointer to new stack location.
+  movl    w1, 0x3f00b200
+  ldr     w0, [x1, #0x04]                         // w0 = [0x3f00b204]
+  cmp     w0, #2
+  b.ne    1f
+  bl      handle_timer_irq
+.if       UART_DEBUG
+  b       2f
+.endif
+1:
+.if       UART_DEBUG
+  bl      log_unknown_interrupt_value
+2:
+.endif
+  ldp     x29, x30, [sp], #16                     // Pop frame pointer, procedure link register off stack.
+  ret
+
+
+handle_irq_bcm2711:
+  stp     x29, x30, [sp, #-16]!                   // Push frame pointer, procedure link register on stack.
+  mov     x29, sp                                 // Update frame pointer to new stack location.
+  movl    w1, 0xfe00b200
+  ldr     w0, [x1]                                // w0 = [0xfe00b200]
+  cmp     w0, #2
+  b.ne    1f
+  bl      handle_timer_irq
+.if       UART_DEBUG
+  b       2f
+.endif
+1:
+.if       UART_DEBUG
+  bl      log_unknown_interrupt_value
+2:
+.endif
+  ldp     x29, x30, [sp], #16                     // Pop frame pointer, procedure link register off stack.
+  ret
+
+
+.if       UART_DEBUG
+
+log_unknown_interrupt_value:
+  stp     x29, x30, [sp, #-16]!                   // Push frame pointer, procedure link register on stack.
+  mov     x29, sp                                 // Update frame pointer to new stack location.
+  adr     x1, msg_unknown_interrupt_value
+  mov     x2, #32
+  bl      hex_x0
+  adr     x0, msg_unknown_interrupt
+  bl      uart_puts
+  ldp     x29, x30, [sp], #16                     // Pop frame pointer, procedure link register off stack.
+  ret
+
+msg_unknown_interrupt:
+  .ascii "Unknown interrupt: 0x"                  // concatenates with the string below
+msg_unknown_interrupt_value:
+  .asciz "........\r\n"                           // stops (.) are replaced with value in hex_x0 routine
+
+.endif

--- a/src/spectrum4/kernel/pci.s
+++ b/src/spectrum4/kernel/pci.s
@@ -2,8 +2,6 @@
 # Licencing information can be found in the LICENCE file
 # (C) 2021 Spectrum +4 Authors. All rights reserved.
 
-.align 2
-
 # pci_bus
 #   0x00-0x07: parent
 
@@ -17,6 +15,7 @@
 #
 # Based on:
 #   https://github.com/raspberrypi/linux/blob/14b35093ca68bf2c81bbc90aace5007142b40b40/drivers/pci/controller/pcie-brcmstb.c#L707-L722
+.align 2
 brcm_pcie_map_conf:
 
 

--- a/src/spectrum4/kernel/reboot.s
+++ b/src/spectrum4/kernel/reboot.s
@@ -16,6 +16,7 @@
 # #   https://github.com/torvalds/linux/blob/366a4e38b8d0d3e8c7673ab5c1b5e76bbfbc0085/drivers/firmware/raspberrypi.c#L249-L257
 # #   https://github.com/torvalds/linux/blob/366a4e38b8d0d3e8c7673ab5c1b5e76bbfbc0085/drivers/watchdog/bcm2835_wdt.c#L100-L123
 # # ------------------------------------------------------------------------------
+# .align 2
 # reboot:
 # .if       UART_DEBUG
 #   adr     x0, msg_rebooting

--- a/src/spectrum4/kernel/timer.s
+++ b/src/spectrum4/kernel/timer.s
@@ -1,0 +1,30 @@
+# This file is part of the Spectrum +4 Project.
+# Licencing information can be found in the LICENCE file
+# (C) 2021 Spectrum +4 Authors. All rights reserved.
+
+
+.align 2
+timer_init:
+  adr     x0, mailbox_base                        // x0 = mailbox_base
+  ldr     x0, [x0, timer_base-mailbox_base]       // x0 = [timer_base] = 0x000000003f003000 (rpi3) or 0x00000000fe003000 (rpi4)
+  ldr     w1, [x0, #0x04]
+  movl    w2, 200000                              // TODO: this value should be dependent on clock speed (different for rpi3/rpi4)
+  add     w1, w1, w2
+  str     w1, [x0, #0x10]                         // [0x3f003010] += [0x3f003004] + 200000 (rpi3) /  [0xfe003010] += [0xfe003004] + 200000 (rpi4)
+  ret
+
+
+handle_timer_irq:
+  stp     x29, x30, [sp, #-16]!                   // Push frame pointer, procedure link register on stack.
+  mov     x29, sp                                 // Update frame pointer to new stack location.
+  bl      timer_init                              // [0x3f003010] += [0x3f003004] + 200000 (rpi3) /  [0xfe003010] += [0xfe003004] + 200000 (rpi4)
+  mov     w1, #0x02
+  str     w1, [x0]                                // [0x3f003000] = 2 (rpi3) / [0xfe003000] = 2 (rpi4)
+  bl      timed_interrupt
+  ldp     x29, x30, [sp], #0x10                   // Pop frame pointer, procedure link register off stack.
+  ret
+
+
+timed_interrupt:
+# log     '.'                                     // uncomment to check that interrupt routine is firing
+  ret

--- a/src/spectrum4/roms/new.s
+++ b/src/spectrum4/roms/new.s
@@ -10,6 +10,15 @@ new:                                     // L019D
   and     sp, x1, #~0x0f                          // sp = highest 16-byte aligned address equal to or lower than ([RAMTOP] + 1).
   mov     x29, 0                                  // Frame pointer 0 indicates end of stack.
 
+  bl      irq_vector_init
+  dsb     sy                                      // TODO: Not sure if this is needed at all, or if a less aggressive barrier can be used
+  bl      timer_init
+  dsb     sy                                      // TODO: Not sure if this is needed at all, or if a less aggressive barrier can be used
+  ldr     x0, enable_ic
+  blr     x0
+  dsb     sy                                      // TODO: Not sure if this is needed at all, or if a less aggressive barrier can be used
+  bl      enable_irq
+
 .if       UART_DEBUG
 # RPi version logging
   mov     x0, msg_rpi_model


### PR DESCRIPTION
Configure timer interrupts and enable.
The timer interrupt handler currently does nothing.
Interrupts fired every 200,000 system clock cycles (currently independent of clock speed).
Implemented for all supported models (rpi3b/rpi4/rpi400).